### PR TITLE
feat: Create shell code to automate running app

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -31,3 +31,4 @@ jobs:
             - name: Push Docker image
               run: |
                 docker push ${{ secrets.DOCKER_USERNAME }}/microblog-prod:${{ github.sha }}
+                docker push ${{ secrets.DOCKER_USERNAME }}/microblog-prod:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,21 +8,20 @@ services:
       restart: no
 
   mysql:
-    image: mysql:8.0
+    image: mysql/mysql-server:5.7
     ports:
       - 3306:3306
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_ROOT_PASSWORD: root_password
+      MYSQL_RANDOM_ROOT_PASSWORD: yes
     networks:
       microblog:
         ipv4_address: 192.168.1.100
     restart: "always"
     volumes:
       - db_data:/var/lib/mysql
-      - ./my.cnf:/etc/mysql/my.cnf
 
   prod:
     container_name: "microblog-server"

--- a/my.cnf
+++ b/my.cnf
@@ -1,2 +1,0 @@
-[mysqld]
-default_authentication_plugin=mysql_native_password

--- a/runner.sh
+++ b/runner.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Exit on errors
+set -e
+
+# Configuration Variables
+DOCKER_USERNAME=""
+DOCKER_IMAGE="microblog-prod"
+DOCKER_TAG="latest"
+MYSQL_CONTAINER_NAME="mysql"
+APP_CONTAINER_NAME="microblog-server"
+MYSQL_ROOT_PASSWORD=""
+MYSQL_DATABASE="microblog"
+MYSQL_USER="microblog"
+MYSQL_PASSWORD=""
+SECRET_KEY=""
+DATABASE_URL="mysql+pymysql://$MYSQL_USER:$MYSQL_PASSWORD@mysql/$MYSQL_DATABASE"
+NETWORK_NAME="microblog-net"
+DB_VOLUME="microblog_db_data"
+APP_VOLUME="microblog_app_data"
+# Function to log messages
+log() {
+  echo "[INFO] $1"
+}
+
+log "Starting deployment process..."
+
+log "Cleaning up ..."
+# Clean Up Containers with its network
+for container in $(docker ps -q --filter "network=$NETWORK_NAME"); do
+  docker rm -f "$container"
+done
+docker network rm "$NETWORK_NAME"
+
+log "Create docker network $NETWORK_NAME"
+docker network create "$NETWORK_NAME"
+
+# Log in to Docker Hub
+# log "Logging into Docker Hub..."
+# docker login -u "$DOCKER_USERNAME" || { echo "[ERROR] Docker login failed!"; exit 1; }
+
+# Pull the production image from Docker Hub
+log "Pulling Docker image: $DOCKER_USERNAME/$DOCKER_IMAGE:$DOCKER_TAG"
+docker pull "$DOCKER_USERNAME/$DOCKER_IMAGE:$DOCKER_TAG"
+
+if ! docker volume ls --format '{{.Name}}' | grep -w "$DB_VOLUME"; then
+  log "Creating Volume $DB_VOLUME"
+
+  docker volume create "$DB_VOLUME"
+fi
+
+if ! docker volume ls --format '{{.Name}}' | grep -w "$APP_VOLUME"; then
+  log "Creating Volume $APP_VOLUME"
+
+  docker volume create "$APP_VOLUME"
+fi
+
+docker run -d \
+  --name "$MYSQL_CONTAINER_NAME" \
+  -e MYSQL_RANDOM_ROOT_PASSWORD=yes \
+  -e MYSQL_DATABASE="$MYSQL_DATABASE" \
+  -e MYSQL_USER="$MYSQL_USER" \
+  -e MYSQL_PASSWORD="$MYSQL_PASSWORD" \
+  --network "$NETWORK_NAME" \
+  -v "$DB_VOLUME:/var/lib/mysql" \
+  mysql || { echo "[ERROR] MySQL container failed to start!"; exit 1; }
+
+# Wait for MySQL to initialize
+log "Waiting for MySQL to initialize (30 seconds)..."
+sleep 30
+
+# Run the production container
+log "Starting application container..."
+docker run -d \
+  --name "$APP_CONTAINER_NAME" \
+  --env SECRET_KEY="$SECRET_KEY" \
+  --env DATABASE_URL="$DATABASE_URL" \
+  -v "$APP_VOLUME:/home/microblog" \
+  -p 8000:5000 \
+  --network microblog-net \
+  "$DOCKER_USERNAME/$DOCKER_IMAGE:$DOCKER_TAG" || { echo "[ERROR] App container failed to start!"; exit 1; }
+
+# Confirm all containers are running
+log "Checking running containers..."
+docker ps
+
+log "Deployment complete! Access the application at http://localhost:8000"


### PR DESCRIPTION
Create shell code to automate pulling, configuring and running the microblog-prod image
docker-compose.yml changes:
- Use mysql/mysql-server:5.7 instead of mysql image
- Use MYSQL_RANDOM_ROOT_PASSWORD instead of using a password

CD - Push image twice. One as "latest" tag and One as a "github hash" tag.
     This will make sure that the "latest" tag is always up to date and
     in the same way keep the version history.

Resolves U8 in KMOM01
